### PR TITLE
Add clear grid control and inverted bit pattern display

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,21 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <div id="grid" class="grid"></div>
+    <div class="grid-wrapper">
+        <div id="grid" class="grid"></div>
+        <button id="clear">Clear</button>
+    </div>
     <button id="generate">Generate Bit Pattern</button>
-    <textarea id="bitPattern" rows="8" cols="8" readonly></textarea>
+    <div class="textarea-wrapper">
+        <div class="textarea-group">
+            <textarea id="bitPattern" rows="8" cols="8"></textarea>
+            <div class="caption">bit pattern</div>
+        </div>
+        <div class="textarea-group">
+            <textarea id="invertedPattern" rows="8" cols="8" readonly></textarea>
+            <div class="caption">inverted bit pattern</div>
+        </div>
+    </div>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -2,6 +2,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const grid = document.getElementById('grid');
     const generateButton = document.getElementById('generate');
     const bitPatternArea = document.getElementById('bitPattern');
+    const clearButton = document.getElementById('clear');
+    const invertedPatternArea = document.getElementById('invertedPattern');
 
     for (let i = 0; i < 64; i++) {
         const cell = document.createElement('div');
@@ -10,6 +12,17 @@ document.addEventListener('DOMContentLoaded', () => {
             cell.classList.toggle('active');
         });
         grid.appendChild(cell);
+    }
+
+    const updateInverted = () => {
+        if (!invertedPatternArea) return;
+        const lines = bitPatternArea.value.split('\n');
+        const inverted = lines.map(line => line.split('').reverse().join(''));
+        invertedPatternArea.value = inverted.join('\n');
+    };
+
+    if (bitPatternArea) {
+        bitPatternArea.addEventListener('input', updateInverted);
     }
 
     if (generateButton && bitPatternArea) {
@@ -25,6 +38,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 rows.push(line);
             }
             bitPatternArea.value = rows.join('\n');
+            updateInverted();
+        });
+    }
+
+    if (clearButton) {
+        clearButton.addEventListener('click', () => {
+            const cells = grid.children;
+            for (let i = 0; i < cells.length; i++) {
+                cells[i].classList.remove('active');
+            }
+            if (bitPatternArea) bitPatternArea.value = '';
+            if (invertedPatternArea) invertedPatternArea.value = '';
         });
     }
 });

--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,12 @@ body {
     background-color: #f4f4f4;
 }
 
+.grid-wrapper {
+    display: flex;
+    align-items: flex-start;
+    gap: 20px;
+}
+
 .grid {
     display: grid;
     grid-template-columns: repeat(8, 50px);
@@ -31,7 +37,28 @@ button {
     margin-top: 20px;
 }
 
+#clear {
+    margin-top: 0;
+}
+
 textarea {
     margin-top: 10px;
     font-family: monospace;
+}
+
+.textarea-wrapper {
+    display: flex;
+    gap: 20px;
+}
+
+.textarea-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.caption {
+    margin-top: 5px;
+    font-size: 14px;
+    text-align: center;
 }

--- a/test.js
+++ b/test.js
@@ -15,7 +15,8 @@ class Element {
           this.classes.add(cls);
         }
       },
-      contains: function(cls){return this.classes.has(cls);}
+      contains: function(cls){return this.classes.has(cls);},
+      remove: function(cls){this.classes.delete(cls);}
     };
   }
   appendChild(child){
@@ -24,10 +25,13 @@ class Element {
   addEventListener(event, cb){
     this.eventListeners[event] = cb;
   }
-  click(){
-    if (this.eventListeners['click']){
-      this.eventListeners['click']();
+  trigger(event){
+    if (this.eventListeners[event]){
+      this.eventListeners[event]();
     }
+  }
+  click(){
+    this.trigger('click');
   }
 }
 
@@ -37,6 +41,10 @@ const generateButton = new Element();
 generateButton.id = 'generate';
 const bitPattern = new Element();
 bitPattern.id = 'bitPattern';
+const clearButton = new Element();
+clearButton.id = 'clear';
+const invertedPattern = new Element();
+invertedPattern.id = 'invertedPattern';
 
 const documentStub = {
   eventListeners: {},
@@ -52,6 +60,8 @@ const documentStub = {
     if (id === 'grid') return grid;
     if (id === 'generate') return generateButton;
     if (id === 'bitPattern') return bitPattern;
+    if (id === 'clear') return clearButton;
+    if (id === 'invertedPattern') return invertedPattern;
     return null;
   },
   createElement(tag){
@@ -78,5 +88,18 @@ cell.click(); // activate first cell again
 generateButton.click();
 const expectedPattern = '10000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000';
 assert.strictEqual(bitPattern.value, expectedPattern, 'bit pattern should reflect grid state');
+const expectedInverted = '00000001\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000';
+assert.strictEqual(invertedPattern.value, expectedInverted, 'inverted pattern should mirror bit pattern');
+
+// test inversion on manual input
+bitPattern.value = '00000001';
+bitPattern.trigger('input');
+assert.strictEqual(invertedPattern.value, '10000000', 'inverted pattern should update on input');
+
+// test clear functionality
+clearButton.click();
+assert(grid.children.every(c => !c.classList.contains('active')), 'all cells should be inactive after clear');
+assert.strictEqual(bitPattern.value, '', 'bit pattern should be cleared');
+assert.strictEqual(invertedPattern.value, '', 'inverted pattern should be cleared');
 
 console.log('All tests passed');


### PR DESCRIPTION
## Summary
- Add side Clear button to reset grid and bit patterns
- Display original and horizontally inverted bit patterns with captions
- Style layout for new controls and document inversion logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68acb2820b808328ba437331fd2b06b5