### PR TITLE
Refactor grid to 8x7 and handle leading zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GraphIIx
 
-GraphIIx is a minimal web-based pixel editor inspired by the Apple II. It displays an 8×8 grid of cells that can be toggled on and off to create simple monochrome graphics.
+GraphIIx is a minimal web-based pixel editor inspired by the Apple II. It displays an 8×7 grid of cells that can be toggled on and off to create simple monochrome graphics.
 
 ## Running the app
 
@@ -18,5 +18,5 @@ This executes `test.js`, which stubs the DOM and exercises the grid logic.
 
 ## Design notes
 
-On `DOMContentLoaded`, `script.js` constructs a grid of 64 `<div>` elements inside the `#grid` container. Each cell listens for click events that toggle the `active` class. `styles.css` lays out the 8×8 grid and colours active cells black. The lightweight structure makes it easy for developers to extend the editor with additional features such as larger canvases or colour support.
+On `DOMContentLoaded`, `script.js` constructs a grid of 56 `<div>` elements inside the `#grid` container. Each cell listens for click events that toggle the `active` class. `styles.css` lays out the 8×7 grid and colours active cells black. The lightweight structure makes it easy for developers to extend the editor with additional features such as larger canvases or colour support.
 

--- a/script.js
+++ b/script.js
@@ -8,7 +8,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const loadButton = document.getElementById('load');
     const fileInput = document.getElementById('fileInput');
 
-    for (let i = 0; i < 64; i++) {
+    const ROWS = 8;
+    const COLS = 7;
+    for (let i = 0; i < ROWS * COLS; i++) {
         const cell = document.createElement('div');
         cell.classList.add('cell');
         cell.addEventListener('click', () => {
@@ -20,10 +22,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const generatePattern = () => {
         const cells = grid.children;
         const rows = [];
-        for (let r = 0; r < 8; r++) {
-            let line = '';
-            for (let c = 0; c < 8; c++) {
-                const cell = cells[r * 8 + c];
+        for (let r = 0; r < ROWS; r++) {
+            let line = '0';
+            for (let c = 0; c < COLS; c++) {
+                const cell = cells[r * COLS + c];
                 line += cell.classList.contains('active') ? '1' : '0';
             }
             rows.push(line);
@@ -37,10 +39,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const applyPatternToGrid = (pattern) => {
         const lines = pattern.split(/\r?\n/);
         const cells = grid.children;
-        for (let r = 0; r < 8; r++) {
-            for (let c = 0; c < 8; c++) {
-                const cell = cells[r * 8 + c];
-                if (lines[r] && lines[r][c] === '1') {
+        for (let r = 0; r < ROWS; r++) {
+            for (let c = 0; c < COLS; c++) {
+                const cell = cells[r * COLS + c];
+                if (lines[r] && lines[r][c + 1] === '1') {
                     cell.classList.add('active');
                 } else {
                     cell.classList.remove('active');

--- a/styles.css
+++ b/styles.css
@@ -32,7 +32,7 @@ body {
 
 .grid {
     display: grid;
-    grid-template-columns: repeat(8, 50px);
+    grid-template-columns: repeat(7, 50px);
     grid-template-rows: repeat(8, 50px);
     gap: 2px;
 }

--- a/test.js
+++ b/test.js
@@ -98,7 +98,7 @@ require('./script.js');
 
 document.dispatchEvent('DOMContentLoaded');
 
-assert.strictEqual(grid.children.length, 64, 'should create 64 cells');
+assert.strictEqual(grid.children.length, 56, 'should create 56 cells');
 
 const cell = grid.children[0];
 cell.click();
@@ -109,9 +109,9 @@ assert(!cell.classList.contains('active'), 'cell should not be active after seco
 // test bit pattern generation
 cell.click(); // activate first cell again
 generateButton.click();
-const expectedPattern = '10000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000';
+const expectedPattern = '01000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000';
 assert.strictEqual(bitPattern.value, expectedPattern, 'bit pattern should reflect grid state');
-const expectedInverted = '00000001\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000';
+const expectedInverted = '00000010\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000';
 assert.strictEqual(invertedPattern.value, expectedInverted, 'inverted pattern should mirror bit pattern');
 
 // test inversion on manual input
@@ -131,8 +131,8 @@ saveButton.click();
 assert.strictEqual(bitPattern.value, expectedPattern, 'save should generate bit pattern before downloading');
 
 // test load functionality
-const loadPattern = '01000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000';
-const loadInverted = '00000010\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000';
+const loadPattern = '00100000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000';
+const loadInverted = '00000100\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000';
 fileInput.files = [{ content: loadPattern }];
 fileInput.trigger('change', { target: fileInput });
 assert(grid.children[1].classList.contains('active'), 'grid should reflect loaded pattern');


### PR DESCRIPTION
## Summary
- Switch canvas to 8x7 cells and include leading zero in each bit pattern line
- Ignore the leading zero when loading patterns so the 7-bit data maps to the grid correctly
- Update layout, docs, and tests for the new 8x7 grid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68accdca39c8832897a23524cb2a05e5