### PR TITLE
Add hexadecimal display for inverted bit patterns

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,10 @@
             <textarea id="invertedPattern" rows="8" cols="8" readonly></textarea>
             <div class="caption">inverted bit pattern</div>
         </div>
+        <div class="textarea-group">
+            <textarea id="hexPattern" rows="8" cols="3" readonly></textarea>
+            <div class="caption">hex pattern</div>
+        </div>
     </div>
     <script src="script.js"></script>
 </body>

--- a/script.js
+++ b/script.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const bitPatternArea = document.getElementById('bitPattern');
     const clearButton = document.getElementById('clear');
     const invertedPatternArea = document.getElementById('invertedPattern');
+    const hexPatternArea = document.getElementById('hexPattern');
     const saveButton = document.getElementById('save');
     const loadButton = document.getElementById('load');
     const fileInput = document.getElementById('fileInput');
@@ -52,10 +53,20 @@ document.addEventListener('DOMContentLoaded', () => {
     };
 
     const updateInverted = () => {
-        if (!invertedPatternArea) return;
+        if (!bitPatternArea) return;
         const lines = bitPatternArea.value.split('\n');
         const inverted = lines.map(line => line.split('').reverse().join(''));
-        invertedPatternArea.value = inverted.join('\n');
+        if (invertedPatternArea) {
+            invertedPatternArea.value = inverted.join('\n');
+        }
+        if (hexPatternArea) {
+            const hex = inverted.map(line => {
+                if (!line.trim()) return '';
+                const value = parseInt(line, 2);
+                return '$' + value.toString(16).toUpperCase().padStart(2, '0');
+            });
+            hexPatternArea.value = hex.join('\n');
+        }
     };
 
     if (bitPatternArea) {
@@ -102,6 +113,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             if (bitPatternArea) bitPatternArea.value = '';
             if (invertedPatternArea) invertedPatternArea.value = '';
+            if (hexPatternArea) hexPatternArea.value = '';
         });
     }
 });

--- a/test.js
+++ b/test.js
@@ -46,6 +46,8 @@ const clearButton = new Element();
 clearButton.id = 'clear';
 const invertedPattern = new Element();
 invertedPattern.id = 'invertedPattern';
+const hexPattern = new Element();
+hexPattern.id = 'hexPattern';
 const saveButton = new Element();
 saveButton.id = 'save';
 const loadButton = new Element();
@@ -69,6 +71,7 @@ const documentStub = {
     if (id === 'bitPattern') return bitPattern;
     if (id === 'clear') return clearButton;
     if (id === 'invertedPattern') return invertedPattern;
+    if (id === 'hexPattern') return hexPattern;
     if (id === 'save') return saveButton;
     if (id === 'load') return loadButton;
     if (id === 'fileInput') return fileInput;
@@ -113,17 +116,21 @@ const expectedPattern = '01000000\n00000000\n00000000\n00000000\n00000000\n00000
 assert.strictEqual(bitPattern.value, expectedPattern, 'bit pattern should reflect grid state');
 const expectedInverted = '00000010\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000';
 assert.strictEqual(invertedPattern.value, expectedInverted, 'inverted pattern should mirror bit pattern');
+const expectedHex = '$02\n$00\n$00\n$00\n$00\n$00\n$00\n$00';
+assert.strictEqual(hexPattern.value, expectedHex, 'hex pattern should reflect inverted pattern');
 
 // test inversion on manual input
 bitPattern.value = '00000001';
 bitPattern.trigger('input');
 assert.strictEqual(invertedPattern.value, '10000000', 'inverted pattern should update on input');
+assert.strictEqual(hexPattern.value, '$80', 'hex pattern should update on input');
 
 // test clear functionality
 clearButton.click();
 assert(grid.children.every(c => !c.classList.contains('active')), 'all cells should be inactive after clear');
 assert.strictEqual(bitPattern.value, '', 'bit pattern should be cleared');
 assert.strictEqual(invertedPattern.value, '', 'inverted pattern should be cleared');
+assert.strictEqual(hexPattern.value, '', 'hex pattern should be cleared');
 
 // test save functionality
 cell.click();
@@ -133,10 +140,12 @@ assert.strictEqual(bitPattern.value, expectedPattern, 'save should generate bit 
 // test load functionality
 const loadPattern = '00100000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000';
 const loadInverted = '00000100\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000';
+const loadHex = '$04\n$00\n$00\n$00\n$00\n$00\n$00\n$00';
 fileInput.files = [{ content: loadPattern }];
 fileInput.trigger('change', { target: fileInput });
 assert(grid.children[1].classList.contains('active'), 'grid should reflect loaded pattern');
 assert.strictEqual(bitPattern.value, loadPattern, 'bit pattern should match loaded file');
 assert.strictEqual(invertedPattern.value, loadInverted, 'inverted pattern should update after load');
+assert.strictEqual(hexPattern.value, loadHex, 'hex pattern should update after load');
 
 console.log('All tests passed');


### PR DESCRIPTION
## Summary
- add third textarea showing hex values for each inverted bit pattern row
- compute and render `$`-prefixed hex bytes alongside inverted patterns
- expand tests to cover hex output and clearing behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acd07298e48328a3193a6ab5f83af9