### PR TITLE
Center grid and move control buttons

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -25,13 +25,15 @@ body {
 }
 
 .grid-wrapper {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 20px;
+    position: relative;
+    display: inline-block;
 }
 
 .button-wrapper {
+    position: absolute;
+    top: 0;
+    left: 100%;
+    margin-left: 20px;
     display: flex;
     flex-direction: column;
 }


### PR DESCRIPTION
## Summary
- Center the drawing grid relative to the page title
- Position Clear, Save, and Load buttons vertically to the right of the grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ade8f603148328abfb6addd8ad1618