### PR TITLE
Invert generated bit patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 GraphIIx is a minimal web-based pixel editor inspired by the Apple II. It displays an 8×7 grid of cells that can be toggled on and off to create simple monochrome graphics.
 
 The editor can generate three representations of the drawing: a raw bit pattern, a hexadecimal pattern and a decimal pattern.
+When generating, each bit pattern line is horizontally inverted so that a sequence like `10001000` becomes `00010001`.
 
 ## Running the app
 

--- a/script.js
+++ b/script.js
@@ -30,6 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const cell = cells[r * COLS + c];
                 line += cell.classList.contains('active') ? '1' : '0';
             }
+            line = line.split('').reverse().join('');
             rows.push(line);
         }
         const pattern = rows.join('\n');

--- a/test.js
+++ b/test.js
@@ -115,13 +115,13 @@ assert(!cell.classList.contains('active'), 'cell should not be active after seco
 // test bit pattern generation
 cell.click(); // activate first cell again
 generateButton.click();
-const expectedPattern = '01000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000';
+const expectedPattern = '00000010\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000\n00000000';
 assert.strictEqual(bitPattern.value, expectedPattern, 'bit pattern should reflect grid state');
-const expectedHex = '$40\n$00\n$00\n$00\n$00\n$00\n$00\n$00';
+const expectedHex = '$02\n$00\n$00\n$00\n$00\n$00\n$00\n$00';
 assert.strictEqual(hexPattern.value, expectedHex, 'hex pattern should reflect bit pattern');
-const expectedDec = '64\n0\n0\n0\n0\n0\n0\n0';
+const expectedDec = '2\n0\n0\n0\n0\n0\n0\n0';
 assert.strictEqual(decPattern.value, expectedDec, 'dec pattern should reflect bit pattern');
-const expectedBasic = '100 POKE BA%,64\n110 POKE BA% + 1024,0\n120 POKE BA% + 2048,0\n130 POKE BA% + 3072,0\n140 POKE BA% + 4096,0\n150 POKE BA% + 5120,0\n160 POKE BA% + 6144,0\n170 POKE BA% + 7168,0';
+const expectedBasic = '100 POKE BA%,2\n110 POKE BA% + 1024,0\n120 POKE BA% + 2048,0\n130 POKE BA% + 3072,0\n140 POKE BA% + 4096,0\n150 POKE BA% + 5120,0\n160 POKE BA% + 6144,0\n170 POKE BA% + 7168,0';
 assert.strictEqual(basicCommands.value, expectedBasic, 'BASIC commands should reflect dec pattern');
 
 // test hex update on manual input


### PR DESCRIPTION
## Summary
- Reverse each row's bits when generating patterns so output like `10001000` becomes `00010001`.
- Document bit-pattern inversion behavior.
- Update tests to cover bit reversal and ensure save functionality reflects inverted bits.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0230d5048328ba4046a5eb92d93b